### PR TITLE
return an unknown error even if not TRPCError

### DIFF
--- a/src/adapters/node-http/errors.ts
+++ b/src/adapters/node-http/errors.ts
@@ -2,17 +2,19 @@ import { TRPCError } from '@trpc/server';
 import { TRPC_ERROR_CODES_BY_KEY } from '@trpc/server/rpc';
 
 export const getErrorFromUnknown = (error: unknown): TRPCError => {
-  if (error instanceof TRPCError) {
-    return error;
+  if (error instanceof Error && error.name === 'TRPCError') {
+    return error as TRPCError;
   }
 
-  const code = (error as any).code as keyof typeof TRPC_ERROR_CODES_BY_KEY
-  const errorToString = typeof (error as any).toString === "function" ? (error as any).toString() : undefined;
+  const code = (error as any).code as keyof typeof TRPC_ERROR_CODES_BY_KEY;
+  const errorToString =
+    typeof (error as any).toString === 'function' ? (error as any).toString() : undefined;
   return new TRPCError({
     code: TRPC_ERROR_CODES_BY_KEY[code] ? code : 'INTERNAL_SERVER_ERROR',
-    message: error instanceof Error 
-      ? error.message 
-      : errorToString 
+    message:
+      error instanceof Error
+        ? error.message
+        : errorToString
         ? errorToString
         : 'Unknown error occurred',
   });


### PR DESCRIPTION
This was preventing our team from returning an error for a redirection. I left out your instance of TRPCError because I think the change encapsulates it as a general error, but apparently checking for instance of TRPCError was failing even though it is one.